### PR TITLE
ensure value is a string when appending UNIX LE

### DIFF
--- a/lib/file-pipeline/stringify.js
+++ b/lib/file-pipeline/stringify.js
@@ -34,7 +34,7 @@ function stringify(context, file) {
   }
 
   /* Ensure valid UNIX file. */
-  if (value && value.charAt(value.length - 1) !== '\n') {
+  if (typeof value === 'string' && value !== '' && value.charAt(value.length - 1) !== '\n') {
     value += '\n';
   }
 


### PR DESCRIPTION
Writing binary contents is broken without this. The binary prototypes don't have a `charAt` function.

You can reproduce with:

```javascript
function binaryCompiler(opts) {
  this.Compiler = function(root, file) {
    return new Buffer([1,2,3]);
  };
}
```