### PR TITLE
Add support for ignore patterns as option

### DIFF
--- a/doc/ignore.md
+++ b/doc/ignore.md
@@ -17,6 +17,14 @@ The first file named `ignoreName` in the parent directory of a checked path is
 used.
 Or, if no file is found, the parent directory if searched, and so on.
 
+## Additional ignoring
+
+In addition to explicit and implicit ignore files, other patterns can be given
+with [`ignorePatterns`][ignore-patterns].
+The format of each pattern in `ignorePattern` is the same as a line in an ignore
+file.
+Patterns and files are resolved based on the current working directory.
+
 ## Ignoring
 
 Ignoring is used when searching for files in directories.
@@ -61,6 +69,8 @@ test/{input,tree}
 [ignore-name]: options.md#optionsignorename
 
 [ignore-path]: options.md#optionsignorepath
+
+[ignore-patterns]: options.md#optionsignorepatterns
 
 [silently-ignore]: options.md#optionssilentlyignore
 

--- a/doc/options.md
+++ b/doc/options.md
@@ -27,6 +27,7 @@
 *   [options.ignoreName](#optionsignorename)
 *   [options.detectIgnore](#optionsdetectignore)
 *   [options.ignorePath](#optionsignorepath)
+*   [options.ignorePatterns](#optionsignorepatterns)
 *   [options.silentlyIgnore](#optionssilentlyignore)
 *   [options.plugins](#optionsplugins)
 *   [options.pluginPrefix](#optionspluginprefix)
@@ -920,6 +921,36 @@ engine(
     files: ['.'],
     extensions: ['md'],
     ignorePath: '.gitignore'
+  },
+  done
+)
+
+function done(error) {
+  if (error) throw error
+}
+```
+
+## `options.ignorePatterns`
+
+Additional patterns to use to ignore files.
+
+*   Type: `Array.<string>`, optional
+
+###### Example
+
+The following example processes files in the current working directory with an
+`md` extension, except for `readme.md`:
+
+```js
+var engine = require('unified-engine')
+var remark = require('remark')
+
+engine(
+  {
+    processor: remark(),
+    files: ['.'],
+    extensions: ['md'],
+    ignorePatterns: ['readme.md']
   },
   done
 )

--- a/lib/file-set-pipeline/file-system.js
+++ b/lib/file-set-pipeline/file-system.js
@@ -18,6 +18,7 @@ function fileSystem(context, settings, next) {
         cwd: settings.cwd,
         extensions: settings.extensions,
         silentlyIgnore: settings.silentlyIgnore,
+        ignorePatterns: settings.ignorePatterns,
         ignore: new Ignore({
           cwd: settings.cwd,
           detectIgnore: settings.detectIgnore,

--- a/lib/finder.js
+++ b/lib/finder.js
@@ -2,6 +2,7 @@
 
 var path = require('path')
 var fs = require('fs')
+var gitignore = require('ignore')
 var glob = require('glob')
 var vfile = require('to-vfile')
 var xtend = require('xtend')
@@ -103,6 +104,7 @@ function search(input, options, next) {
   var silent = options.silentlyIgnore
   var nested = options.nested
   var extensions = options.extensions
+  var extraIgnore = gitignore().add(options.ignorePatterns)
   var files = []
   var expected = 0
   var actual = 0
@@ -132,7 +134,7 @@ function search(input, options, next) {
 
     expected++
 
-    statAndIgnore(file, options, handle)
+    statAndIgnore(file, xtend(options, {extraIgnore: extraIgnore}), handle)
 
     function handle(error, result) {
       var ignored = result && result.ignored
@@ -216,7 +218,9 @@ function search(input, options, next) {
 
 function statAndIgnore(file, options, callback) {
   var ignore = options.ignore
+  var extraIgnore = options.extraIgnore
   var fp = resolve(options.cwd, filePath(file))
+  var normal = relative(options.cwd, fp)
   var expected = 1
   var actual = 0
   var stats
@@ -246,7 +250,10 @@ function statAndIgnore(file, options, callback) {
       callback(error)
       actual = -1
     } else if (actual === expected) {
-      callback(null, {stats: stats, ignored: ignored})
+      callback(null, {
+        stats: stats,
+        ignored: ignored || (normal ? extraIgnore.ignores(normal) : false)
+      })
     }
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,6 +109,7 @@ function run(options, callback) {
       : detectIgnore
   settings.ignoreName = options.ignoreName || null
   settings.ignorePath = options.ignorePath || null
+  settings.ignorePatterns = options.ignorePatterns || []
   settings.silentlyIgnore = Boolean(options.silentlyIgnore)
 
   if (detectIgnore && !hasIgnore) {

--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,8 @@ done.
     — Whether to search for ignore files
 *   [`ignorePath`][ignore-path] (`string`, optional)
     — Filepath to an ignore file to load
+*   [`ignorePatterns`][ignore-patterns] (`Array.<string>`, optional)
+    — Patterns to ignore in addition to ignore files, if any
 *   [`silentlyIgnore`][silently-ignore] (`boolean`, default: `false`)
     — Skip given files if they are ignored
 *   [`plugins`][options-plugins] (`Array|Object`, optional)
@@ -281,6 +283,8 @@ abide by its terms.
 [ignore-name]: doc/options.md#optionsignorename
 
 [ignore-path]: doc/options.md#optionsignorepath
+
+[ignore-patterns]: doc/options.md#optionsignorepatterns
 
 [silently-ignore]: doc/options.md#optionssilentlyignore
 

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -11,7 +11,7 @@ var join = path.join
 var fixtures = join(__dirname, 'fixtures')
 
 test('ignore', function(t) {
-  t.plan(5)
+  t.plan(7)
 
   t.test('should fail fatally when given ignores are not found', function(st) {
     var cwd = join(fixtures, 'simple-structure')
@@ -164,6 +164,64 @@ test('ignore', function(t) {
         'one.txt: no issues found',
         ''
       ].join('\n')
+
+      st.deepEqual(
+        [error, code, stderr()],
+        [null, 0, expected],
+        'should report'
+      )
+    }
+  })
+
+  t.test('should support ignore patterns', function(st) {
+    var stderr = spy()
+
+    st.plan(1)
+
+    engine(
+      {
+        processor: noop,
+        cwd: join(fixtures, 'simple-structure'),
+        streamError: stderr.stream,
+        files: ['.'],
+        ignorePatterns: ['**/t*.*'],
+        extensions: ['txt']
+      },
+      onrun
+    )
+
+    function onrun(error, code) {
+      var expected = ['one.txt: no issues found', ''].join('\n')
+
+      st.deepEqual(
+        [error, code, stderr()],
+        [null, 0, expected],
+        'should report'
+      )
+    }
+  })
+
+  t.test('should support ignore files and ignore patterns', function(st) {
+    var stderr = spy()
+
+    st.plan(1)
+
+    engine(
+      {
+        processor: noop,
+        cwd: join(fixtures, 'ignore-file'),
+        streamError: stderr.stream,
+        files: ['.'],
+        detectIgnore: true,
+        ignoreName: '.fooignore',
+        ignorePatterns: ['nested'],
+        extensions: ['txt']
+      },
+      onrun
+    )
+
+    function onrun(error, code) {
+      var expected = ['one.txt: no issues found', ''].join('\n')
 
       st.deepEqual(
         [error, code, stderr()],


### PR DESCRIPTION
Closes GH-39.

Reason for not going with normal ignore globs (`remark . !readme.md`) is that [negation was dropped from glob with a reason](https://github.com/isaacs/node-glob#comments-and-negation). I tried it but it would be very difficult to implement.