### PR TITLE
Update breaking dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,5 +20,5 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node:
-          - lts/erbium
+          - lts/fermium
           - lts/gallium

--- a/doc/options.md
+++ b/doc/options.md
@@ -677,7 +677,7 @@ File path of [configuration][configure] file to load.
 If given and [`detectConfig`][detect-config] is not `false`, then:
 
 *   `$rcName` and `$rcName.json` are loaded and parsed as JSON
-*   `$rcName.yml` and `$rcName.yaml` are loaded with `jyaml`
+*   `$rcName.yml` and `$rcName.yaml` are loaded with `yaml`
 *   `$rcName.js` are either `require`d or `import`ed
 *   `$rcName.cjs` are `require`d
 *   `$rcName.mjs` are `import`ed

--- a/doc/options.md
+++ b/doc/options.md
@@ -677,7 +677,7 @@ File path of [configuration][configure] file to load.
 If given and [`detectConfig`][detect-config] is not `false`, then:
 
 *   `$rcName` and `$rcName.json` are loaded and parsed as JSON
-*   `$rcName.yml` and `$rcName.yaml` are loaded with `js-yaml`
+*   `$rcName.yml` and `$rcName.yaml` are loaded with `jyaml`
 *   `$rcName.js` are either `require`d or `import`ed
 *   `$rcName.cjs` are `require`d
 *   `$rcName.mjs` are `import`ed

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -35,7 +35,7 @@
 
 import path from 'node:path'
 import {pathToFileURL} from 'node:url'
-import jsYaml from 'js-yaml'
+import yaml from 'yaml'
 import parseJson from 'parse-json'
 import createDebug from 'debug'
 import {resolvePlugin} from 'load-plugin'
@@ -215,11 +215,10 @@ async function loadScriptOrModule(_, filePath) {
 }
 
 /** @type {Loader} */
-async function loadYaml(buf, filePath) {
+async function loadYaml(buf) {
   // C8 bug on Node@12
   /* c8 ignore next 4 */
-  // @ts-expect-error: Assume it matches config.
-  return jsYaml.load(String(buf), {filename: path.basename(filePath)})
+  return yaml.parse(String(buf))
 }
 
 /** @type {Loader} */

--- a/package.json
+++ b/package.json
@@ -32,26 +32,25 @@
     "@types/concat-stream": "^2.0.0",
     "@types/debug": "^4.0.0",
     "@types/is-empty": "^1.0.0",
-    "@types/js-yaml": "^4.0.0",
     "@types/node": "^17.0.0",
     "@types/unist": "^2.0.0",
     "concat-stream": "^2.0.0",
     "debug": "^4.0.0",
     "fault": "^2.0.0",
-    "glob": "^7.0.0",
+    "glob": "^8.0.0",
     "ignore": "^5.0.0",
     "is-buffer": "^2.0.0",
     "is-empty": "^1.0.0",
     "is-plain-obj": "^4.0.0",
-    "js-yaml": "^4.0.0",
-    "load-plugin": "^4.0.0",
+    "load-plugin": "^5.0.0",
     "parse-json": "^6.0.0",
     "to-vfile": "^7.0.0",
     "trough": "^2.0.0",
     "unist-util-inspect": "^7.0.0",
     "vfile-message": "^3.0.0",
     "vfile-reporter": "^7.0.0",
-    "vfile-statistics": "^2.0.0"
+    "vfile-statistics": "^2.0.0",
+    "yaml": "^2.0.0"
   },
   "devDependencies": {
     "@types/glob": "^7.0.0",
@@ -71,7 +70,7 @@
     "vfile": "^5.0.0",
     "vfile-reporter-json": "^3.0.0",
     "vfile-reporter-pretty": "^6.0.0",
-    "xo": "^0.48.0"
+    "xo": "^0.50.0"
   },
   "scripts": {
     "build": "rimraf \"{lib,test}/**/*.d.ts\" \"*.d.ts\" && tsc && type-coverage",

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The following projects wrap the engine:
 ## Install
 
 This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c):
-Node 12+ is needed to use it and it must be `import`ed instead of `require`d.
+Node 14+ is needed to use it and it must be `import`ed instead of `require`d.
 
 [npm][]:
 


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

- `load-plugin` has been updated to ^5.0.0. This may be breaking due to unforeseen issues.
- `glob` has been updated to ^8.0.0, which drops support for Node.js 12. This is non-breaking for `unified-engine`.
- `js-yaml` has been replaced with `yaml`. This package better follows the YAML standard. This is breaking for users who rely on quirks in `js-yaml`. This also breaks compatibility with Node.js < 14.

Closs #65
Closs #67

<!--do not edit: pr-->
