### PR TITLE
WIP Preserve folder structure from input to output

### DIFF
--- a/lib/file-pipeline/copy.js
+++ b/lib/file-pipeline/copy.js
@@ -27,7 +27,7 @@ export function copy(context, file, next) {
     return
   }
 
-  const outpath = path.resolve(context.settings.cwd, output)
+  const outpath = path.resolve(context.settings.cwd, output, file.dirname)
 
   debug('Copying `%s`', currentPath)
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I might have misunderstood the scope of unified-engine, hence this initial commit meant to raise the question if this type of feature is at all interesting.

Use case: I have source markdown in a folder structure under `cwd`. The `files` glob is `**/*.md` thus matching arbitrary depth. I want to preserve this structure in the `output` folder. Was I right to conclude that this is currently unsupported?

The initial commit only serves to demonstrate how paths would be mapped. If an option for preserving input folder structure is desired I can continue with the following work:

- [ ] Create missing output folders, recursively
- [ ] Tests
- [ ] Option to opt-in (don't change the behavior of existing consumers of the library)

<!--do not edit: pr-->
