### PR TITLE
Update log.js to support async reporter plugins

### DIFF
--- a/lib/file-set-pipeline/log.js
+++ b/lib/file-set-pipeline/log.js
@@ -36,7 +36,7 @@ export async function log(context, settings) {
     func = settings.reporter
   }
 
-  let diagnostics = func(
+  let diagnostics = await func(
     context.files.filter(
       (file) => file.data.unifiedEngineGiven && !file.data.unifiedEngineIgnored
     ),

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@
  * @callback VFileReporter
  * @param {Array<VFile>} files
  * @param {VFileReporterOptions} options
- * @returns {string}
+ * @returns {string | Promise<string>}
  *
  * @typedef Settings
  * @property {Options['processor']} processor

--- a/test/reporting.js
+++ b/test/reporting.js
@@ -18,6 +18,9 @@ const windows = process.platform === 'win32'
 const cross = windows ? '×' : '✖'
 const danger = windows ? '‼' : '⚠'
 
+/** @type {import('unified-engine').VFileReporter} */
+const vfileReporterPrettyAsync = async (files) => vfileReporterPretty(files)
+
 // See: <https://github.com/sindresorhus/eslint-formatter-pretty/blob/159b30a/index.js#L90-L93>.
 const original = process.env.CI
 
@@ -163,6 +166,29 @@ test('reporting', async () => {
           [error, code, stripAnsi(stderr())],
           [null, 0, ''],
           'should support custom given reporters'
+        )
+        resolve(undefined)
+      }
+    )
+  })
+
+  await new Promise((resolve) => {
+    const stderr = spy()
+
+    engine(
+      {
+        processor: noop(),
+        cwd: new URL('two-files/', fixtures),
+        streamError: stderr.stream,
+        files: ['.'],
+        extensions: ['txt'],
+        reporter: vfileReporterPrettyAsync
+      },
+      (error, code) => {
+        assert.deepEqual(
+          [error, code, stripAnsi(stderr())],
+          [null, 0, ''],
+          'should support async reporters'
         )
         resolve(undefined)
       }


### PR DESCRIPTION
Async reporters can be easily supported by `await`ing the reporter function.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Log.js can easily support sync reporter plugins by awaiting the reporter function. Currently the reporter function is called as a sync function.

Example: vfile-reporter-junit
https://github.com/kellyselden/vfile-reporter-junit/blob/master/index.js

<!--do not edit: pr-->
