### PR TITLE
Removing mention of `processor` (obsolete)

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -1,10 +1,9 @@
 # Plugins
 
-Normally, **unified** plugins receive upon attaching two arguments: `processor`
-(the [`Processor`][unified-processor] it’s attached to) and `options` (an
-`Object` users can provide to configure the plugin).
+Normally, **unified** plugins receive a single `options` argument upon attaching
+(an`Object` users can provide to configure the plugin).
 
-If a plugin is attached by **unified-engine**, a third argument is given:
+If a plugin is attached by **unified-engine**, a second argument is given:
 [`fileSet`][file-set].
 
 ###### Example


### PR DESCRIPTION
Follow-on to the fix for issue unifiedjs/unified-195

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [ ] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [ ] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [ ] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [ ] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [ ] If applicable, I’ve added docs and tests

### Description of changes

TODO

<!--do not edit: pr-->
