### PR TITLE
fix: optional properties types mismatched

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -42,7 +42,7 @@
  *
  * @typedef MergeConfiguration
  *   How to merge.
- * @property {string | undefined} prefix
+ * @property {string | undefined} [prefix]
  *   Plugin prefix.
  * @property {string} root
  *   File path to merge from.
@@ -220,9 +220,9 @@ export class Configuration {
   /**
    * This is an internal method, consider it private.
    *
-   * @param {Buffer | undefined} buf
+   * @param {Buffer | undefined} [buf]
    *   File value.
-   * @param {string | undefined} filePath
+   * @param {string | undefined} [filePath]
    *   File path.
    * @returns {Promise<ConfigResult | undefined>}
    *   Result.

--- a/lib/ignore.js
+++ b/lib/ignore.js
@@ -5,7 +5,7 @@
 /**
  * @callback Callback
  *   Callback.
- * @param {Error | undefined} error
+ * @param {Error | undefined} [error]
  *   Error.
  * @param {boolean | undefined} [result]
  *   Whether to ignore.
@@ -16,13 +16,13 @@
  *   Configuration.
  * @property {string} cwd
  *   Base.
- * @property {boolean | undefined} detectIgnore
+ * @property {boolean | undefined} [detectIgnore]
  *   Whether to detect ignore files.
- * @property {string | undefined} ignoreName
+ * @property {string | undefined} [ignoreName]
  *   Basename of ignore files.
- * @property {URL | string | undefined} ignorePath
+ * @property {URL | string | undefined} [ignorePath]
  *   Explicit path to an ignore file.
- * @property {ResolveFrom | undefined} ignorePathResolveFrom
+ * @property {ResolveFrom | undefined} [ignorePathResolveFrom]
  *   How to resolve.
  *
  * @typedef {'cwd' | 'dir'} ResolveFrom


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aunifiedjs&type=issues and https://github.com/orgs/unifiedjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Optional properties types are mismatched

<!--do not edit: pr-->
