### PR TITLE
Add support for writing binary to file system

### DIFF
--- a/lib/file-pipeline/file-system.js
+++ b/lib/file-pipeline/file-system.js
@@ -55,5 +55,5 @@ export function fileSystem(context, file, next) {
   debug('Writing document to `%s`', destinationPath)
 
   file.stored = true
-  fs.writeFile(destinationPath, file.toString(), next)
+  fs.writeFile(destinationPath, file.value, next)
 }

--- a/test/output.js
+++ b/test/output.js
@@ -184,38 +184,75 @@ test('output', async function (t) {
     assert.equal(output, 'two')
   })
 
-  await t.test('should write binary to a path', async function () {
-    const cwd = new URL('simple-structure/', fixtures)
-    const stderr = spy()
-    const binary = () => new Uint8Array([0xde, 0xad, 0xbe, 0xef])
-    const result = await engine({
-      cwd,
-      extensions: ['txt'],
-      files: ['one.txt'],
-      output: 'five.bin',
-      processor: noop().use(
-        /** @type {Plugin<[], Literal, Uint8Array>} */
-        // @ts-expect-error: TS doesn’t get `this`.
-        function () {
-          /** @type {Compiler<Literal, Uint8Array>} */
-          this.compiler = function () {
-            return binary()
+  await t.test(
+    'should write binary in Uint8Array to a path',
+    async function () {
+      const cwd = new URL('simple-structure/', fixtures)
+      const stderr = spy()
+      const result = await engine({
+        cwd,
+        extensions: ['txt'],
+        files: ['one.txt'],
+        output: 'five.bin',
+        processor: noop().use(
+          /** @type {Plugin<[], Literal, Uint8Array>} */
+          // @ts-expect-error: TS doesn’t get `this`.
+          function () {
+            /** @type {Compiler<Literal, Uint8Array>} */
+            this.compiler = function () {
+              return new Uint8Array([0xde, 0xad, 0xbe, 0xef])
+            }
           }
-        }
-      ),
-      streamError: stderr.stream
-    })
+        ),
+        streamError: stderr.stream
+      })
 
-    const input = String(await fs.readFile(new URL('one.txt', cwd)))
-    const output = await fs.readFile(new URL('five.bin', cwd))
+      const input = String(await fs.readFile(new URL('one.txt', cwd)))
+      const output = new Uint8Array(await fs.readFile(new URL('five.bin', cwd)))
 
-    await fs.unlink(new URL('five.bin', cwd))
+      await fs.unlink(new URL('five.bin', cwd))
 
-    assert.equal(result.code, 0)
-    assert.equal(stderr(), 'one.txt > five.bin: written\n')
-    assert.equal(input, '')
-    assert.deepStrictEqual(new Uint8Array(output), binary())
-  })
+      assert.equal(result.code, 0)
+      assert.equal(stderr(), 'one.txt > five.bin: written\n')
+      assert.equal(input, '')
+      assert.deepStrictEqual(output, new Uint8Array([0xde, 0xad, 0xbe, 0xef]))
+    }
+  )
+
+  await t.test(
+    'should write utf-8 text in Uint8Array to a path',
+    async function () {
+      const cwd = new URL('simple-structure/', fixtures)
+      const stderr = spy()
+      const result = await engine({
+        cwd,
+        extensions: ['txt'],
+        files: ['one.txt'],
+        output: 'six.bin',
+        processor: noop().use(
+          /** @type {Plugin<[], Literal, Uint8Array>} */
+          // @ts-expect-error: TS doesn’t get `this`.
+          function () {
+            /** @type {Compiler<Literal, Uint8Array>} */
+            this.compiler = function () {
+              return new TextEncoder().encode('Hi! 🤷‍♂️')
+            }
+          }
+        ),
+        streamError: stderr.stream
+      })
+
+      const input = String(await fs.readFile(new URL('one.txt', cwd)))
+      const output = new Uint8Array(await fs.readFile(new URL('six.bin', cwd)))
+
+      await fs.unlink(new URL('six.bin', cwd))
+
+      assert.equal(result.code, 0)
+      assert.equal(stderr(), 'one.txt > six.bin: written\n')
+      assert.equal(input, '')
+      assert.deepStrictEqual(output, new TextEncoder().encode('Hi! 🤷‍♂️'))
+    }
+  )
 
   await t.test('should write to folders and support URLs', async function () {
     const cwd = new URL('simple-structure/', fixtures)

--- a/test/output.js
+++ b/test/output.js
@@ -184,6 +184,39 @@ test('output', async function (t) {
     assert.equal(output, 'two')
   })
 
+  await t.test('should write binary to a path', async function () {
+    const cwd = new URL('simple-structure/', fixtures)
+    const stderr = spy()
+    const binary = () => new Uint8Array([0xde, 0xad, 0xbe, 0xef])
+    const result = await engine({
+      cwd,
+      extensions: ['txt'],
+      files: ['one.txt'],
+      output: 'five.bin',
+      processor: noop().use(
+        /** @type {Plugin<[], Literal, Uint8Array>} */
+        // @ts-expect-error: TS doesn’t get `this`.
+        function () {
+          /** @type {Compiler<Literal, Uint8Array>} */
+          this.compiler = function () {
+            return binary()
+          }
+        }
+      ),
+      streamError: stderr.stream
+    })
+
+    const input = String(await fs.readFile(new URL('one.txt', cwd)))
+    const output = await fs.readFile(new URL('five.bin', cwd))
+
+    await fs.unlink(new URL('five.bin', cwd))
+
+    assert.equal(result.code, 0)
+    assert.equal(stderr(), 'one.txt > five.bin: written\n')
+    assert.equal(input, '')
+    assert.deepStrictEqual(new Uint8Array(output), binary())
+  })
+
   await t.test('should write to folders and support URLs', async function () {
     const cwd = new URL('simple-structure/', fixtures)
     const stderr = spy()


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aunifiedjs&type=issues and https://github.com/orgs/unifiedjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

https://github.com/orgs/remarkjs/discussions/1473

This PR removes the stringification of `Uint8Array` before writing to the file system, that allows us outputting binary data from compiler (e.g. .docx, images) with cli like remark-cli.

<!--do not edit: pr-->
