### PR TITLE
Loosen the version of @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@types/concat-stream": "^2.0.0",
     "@types/debug": "^4.0.0",
     "@types/is-empty": "^1.0.0",
-    "@types/node": "^22.0.0",
+    "@types/node": "*",
     "@types/unist": "^3.0.0",
     "concat-stream": "^2.0.0",
     "debug": "^4.0.0",


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aunifiedjs&type=issues and https://github.com/orgs/unifiedjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

`@types/node` is a bit different from other type definitions. Most type definitions from DefinitelyTyped define module type mirroring the public package structure. If two versions are installed, they both define types for a different version of the package.

`@types/node` however, declares modules other than `node`. These module definitions may clash. Also `unified-engine` doesn’t have a dependency on Node.js 22, it has a dependency on Node.js builtins that are available between Node.js 16 and the current latest version.

Packages solve this by specifying the `@types/node` dependency range as `*`. The only one that stands out in many cases is `unified-engine`.

<!--do not edit: pr-->
